### PR TITLE
Add more chart configuration options

### DIFF
--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -38,6 +38,18 @@ spec:
           preStop:
             exec:
               command: ["/app/core-dump-agent", "remove"]
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "ibm-core-dump-handler.serviceAccountName" . }}
       volumes:
       - name: host-volume

--- a/charts/templates/pv.yaml
+++ b/charts/templates/pv.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   storageClassName: hostclass 
   capacity:
-    storage: 1Gi
+    storage: {{ .Values.storage }}
   accessModes:
   - ReadWriteOnce 
   persistentVolumeReclaimPolicy: Retain

--- a/charts/templates/pvc.yaml
+++ b/charts/templates/pvc.yaml
@@ -7,6 +7,6 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage }}
   storageClassName: hostclass
 

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,6 +8,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Size of the Persistent volume to create
+storage: 1Gi
+
 daemonset:
     name: "core-dump-handler"
     label: "core-dump-ds"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -27,3 +27,19 @@ clusterRole:
 
 clusterRoleBinding:
   name: "core-dump-event-report"
+
+# nodeSelector & affinity for the daemonset's pod assignment
+# https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#running-pods-on-select-nodes
+nodeSelector: {}
+# eg
+# gpu-enabled: true
+affinity: {}
+
+# Tolerations for the daemonset's pod assignment
+# ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: {}
+# eg
+# - key: "key"
+#   operator: "Equal"
+#   value: "value"
+#   effect: "NoSchedule"


### PR DESCRIPTION
Add ability to configure:
* Affinity & tolerations for the daemonset's pods
* PV size

Default values have been assigned so that the chart's default behaviour remains the same.