### PR TITLE
Add support for ignoring crictl 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ name = "core-dump-agent"
 version = "0.1.0"
 dependencies = [
  "advisory-lock",
+ "dotenv",
  "env_logger",
  "log",
  "rust-s3",

--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           - name: COMP_LOG_LEVEL
             value: {{ .Values.daemonset.composerLogLevel }}
           - name: COMP_IGNORE_CRIO
-            value: {{ .Values.daemonset.composerIgnoreCrio }}
+            value: {{ .Values.daemonset.composerIgnoreCrio | quote }}
           - name: HOST_DIR
             value: {{ .Values.daemonset.hostDirectory }}
           - name: SUID_DUMPABLE

--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
         env:
           - name: COMP_LOG_LEVEL
             value: {{ .Values.daemonset.composerLogLevel }}
+          - name: COMP_IGNORE_CRIO
+            value: {{ .Values.daemonset.composerIgnoreCrio }}
           - name: HOST_DIR
             value: {{ .Values.daemonset.hostDirectory }}
           - name: SUID_DUMPABLE

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -23,7 +23,8 @@ daemonset:
     s3Region : XXX
     vendor: default
     interval: 60000
-         
+    composerIgnoreCrio: "false"
+
 serviceAccount:
   create: true
   name: "core-dump-admin"

--- a/core-dump-agent/Cargo.toml
+++ b/core-dump-agent/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dotenv  = "0.15.0"
 env_logger = "0.8.3"
 log = "0.4.14"
 rust-s3 = "0.26.0"

--- a/core-dump-client/src/main.rs
+++ b/core-dump-client/src/main.rs
@@ -8,7 +8,6 @@ use std::{thread, time};
 use uuid::Uuid;
 
 fn main() -> Result<(), anyhow::Error> {
-
     let matches = match App::new("Core Dump CLI")
     .version("0.2.0")
     .author("Anton Whalley <anton@venshare.com>")


### PR DESCRIPTION
This pr adds a flag to enable the core dump composer to not try and get the meta data from crictl. 
This will make the EKS environment cleaner and also allow for running the binaries in none container scenarios is required.
There is also a fix to clean up the suid properly