### PR TITLE
Allow env-var overriding

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -61,3 +61,15 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render values given either as string or yaml structure.
+Basically copied from https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_tplvalues.tpl
+*/}}
+{{- define "ibm-core-dump-handler.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -5,4 +5,9 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"] 
+  verbs: ["create"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged

--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
             value: {{ .Values.daemonset.suidDumpable | quote }}
           - name: DEPLOY_CRIO_EXE
             value: {{ .Values.daemonset.includeCrioExe | quote }}
-          {{- if .Values.daemonset.manageSecretEnvVars }}
+          {{- if .Values.daemonset.manageStoreSecret }}
           - name: S3_ACCESS_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/templates/daemonset.yaml
+++ b/charts/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         resources:
           requests:
             memory: {{ .Values.image.request_mem }}
-            cpu: {{ .Values.image.request_cpu }} 
+            cpu: {{ .Values.image.request_cpu }}
           limits:
             memory: {{ .Values.image.limit_mem }}
             cpu: {{ .Values.image.limit_cpu }}
@@ -35,13 +35,14 @@ spec:
           - name: COMP_CRIO_IMAGE_CMD
             value:  {{ .Values.daemonset.composerCrioImageCmd }}
           - name: DEPLOY_CRIO_CONFIG
-            value:  {{ .Values.daemonset.DeployCrioConfig | quote }}  
+            value:  {{ .Values.daemonset.DeployCrioConfig | quote }}
           - name: HOST_DIR
             value: {{ .Values.daemonset.hostDirectory }}
           - name: SUID_DUMPABLE
             value: {{ .Values.daemonset.suidDumpable | quote }}
           - name: DEPLOY_CRIO_EXE
             value: {{ .Values.daemonset.includeCrioExe | quote }}
+          {{- if .Values.daemonset.manageSecretEnvVars }}
           - name: S3_ACCESS_KEY
             valueFrom:
               secretKeyRef:
@@ -62,10 +63,14 @@ spec:
               secretKeyRef:
                 name: s3config
                 key: s3Region
+          {{- end }}
           - name: VENDOR
             value: {{ .Values.daemonset.vendor }}
           - name: INTERVAL
             value: {{ .Values.daemonset.interval | quote }}
+          {{- if .Values.daemonset.extraEnvVars }}
+          {{ include "ibm-core-dump-handler.tplvalues.render" ( dict "value" .Values.daemonset.extraEnvVars "context" $) | nindent 10  }}
+          {{- end }}
         command: ["/app/core-dump-agent"]
         lifecycle:
           preStop:

--- a/charts/templates/pvc.yaml
+++ b/charts/templates/pvc.yaml
@@ -8,5 +8,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage }}
-  storageClassName: hostclass
+  storageClassName: {{ .Values.storageClass }}
 

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.manageStoreSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ stringData:
   s3AccessKey: {{ .Values.daemonset.s3AccessKey }}
   s3BucketName: {{ .Values.daemonset.s3BucketName }}
   s3Region: {{ .Values.daemonset.s3Region }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -14,6 +14,8 @@ fullnameOverride: ""
 
 # Size of the Persistent volume to create
 storage: 1Gi
+storageClass: hostclass
+
 
 daemonset:
     name: "core-dump-handler"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -28,7 +28,7 @@ daemonset:
     DeployCrioConfig: false
     includeCrioExe: false
     # S3 access
-    manageSecretEnvVars: true
+    manageStoreSecret: true
     s3AccessKey : XXX
     s3Secret : XXX
     s3BucketName : XXX

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: quay.io/icdh/core-dump-handler:v4.2.0
   pullPolicy: Always
   request_mem: "64Mi"
-  request_cpu: "250m" 
+  request_cpu: "250m"
   limit_mem: "128Mi"
   limit_cpu: "500m"
 
@@ -21,16 +21,20 @@ daemonset:
     hostDirectory: "/var/mnt/core-dump-handler"
     composerLogLevel: "Warn"
     suidDumpable: 2
-    s3AccessKey : XXX
-    s3Secret : XXX
-    s3BucketName : XXX
-    s3Region : XXX
     vendor: default
     interval: 60000
     composerIgnoreCrio: false
     composerCrioImageCmd: "img"
     DeployCrioConfig: false
     includeCrioExe: false
+    # S3 access
+    manageSecretEnvVars: true
+    s3AccessKey : XXX
+    s3Secret : XXX
+    s3BucketName : XXX
+    s3Region : XXX
+    extraEnvVars: ""
+
 serviceAccount:
   create: true
   name: "core-dump-admin"

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -146,7 +146,7 @@ fn run_agent(core_location: &str) {
         s3_region.parse().unwrap()
     } else {
         Region::Custom {
-            region: "".into(),
+            region: s3_region.into(),
             endpoint: custom_location.into(),
         }
     };

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -140,14 +140,16 @@ fn run_agent(core_location: &str) {
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or_default();
     let s3_region = env::var("S3_REGION").unwrap_or_default();
 
-    let custom_location = env::var("S3_LOCATION").unwrap_or_default();
+    let custom_endpoint = env::var("S3_ENDPOINT").unwrap_or_default();
 
-    let region = if custom_location == "" {
+    let region = if custom_endpoint == "" {
         s3_region.parse().unwrap()
     } else {
+        info!("Setting s3 endpoint location to: {}", custom_endpoint);
+
         Region::Custom {
             region: s3_region.into(),
-            endpoint: custom_location.into(),
+            endpoint: custom_endpoint.into(),
         }
     };
 
@@ -166,7 +168,7 @@ fn run_agent(core_location: &str) {
         location_supported: false,
     };
 
-    let bucket = match Bucket::new(&s3.bucket, s3.region, s3.credentials) {
+    let bucket = match Bucket::new_with_path_style(&s3.bucket, s3.region, s3.credentials) {
         Ok(v) => v,
         Err(e) => {
             error!("Bucket Creation Failed: {}", e);

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -140,7 +140,7 @@ fn run_agent(core_location: &str) {
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or_default();
     let s3_region = env::var("S3_REGION").unwrap_or_default();
 
-    let custom_location = env::var("S3_ACCESS_KEY").unwrap_or_default();
+    let custom_location = env::var("S3_LOCATION").unwrap_or_default();
 
     let region = if custom_location == "" {
         s3_region.parse().unwrap()

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), std::io::Error> {
     let deploy_crio_exe = env::var("DEPLOY_CRIO_EXE")
         .unwrap_or_else(|_| "false".to_string())
         .to_lowercase();
-        
+
     let host_location = host_dir.as_str();
     let pattern: String = std::env::args().nth(1).unwrap_or_default();
 
@@ -140,9 +140,20 @@ fn run_agent(core_location: &str) {
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or_default();
     let s3_region = env::var("S3_REGION").unwrap_or_default();
 
+    let custom_location = env::var("S3_ACCESS_KEY").unwrap_or_default();
+
+    let region = if custom_location == "" {
+        s3_region.parse().unwrap()
+    } else {
+        Region::Custom {
+            region: "".into(),
+            endpoint: custom_location.into(),
+        }
+    };
+
     let s3 = Storage {
         name: "aws".into(),
-        region: s3_region.parse().unwrap(),
+        region,
         credentials: Credentials::new(
             Some(s3_access_key.as_str()),
             Some(s3_secret.as_str()),


### PR DESCRIPTION
This allows overriding the env-vars of the daemonset and disabling of builting secret handling.