### PR TITLE
fix!: Update schema and bump tokio scheduler version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "core-dump-composer"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "advisory-lock",
  "anyhow",
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-cron-scheduler"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2c664a1a2c807bb7753c535341089c05b6a5421b7c1956e0226862c069f0b2"
+checksum = "bf4a5188e880d89645ee45e875cefec5bf9a975fe0deb1b6d71445ec22b4c8d6"
 dependencies = [
  "chrono",
  "cron",

--- a/charts/core-dump-handler/Chart.yaml
+++ b/charts/core-dump-handler/Chart.yaml
@@ -29,11 +29,13 @@ maintainers:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add exe path to the dump file
+    - kind: fixed
+      description: Resolved schema issue and bumped tokio scheduler
       links:
         - name: Github PR
-          url: https://github.com/IBM/core-dump-handler/pull/58
+          url: https://github.com/IBM/core-dump-handler/pull/63
+        - name: Github Issue
+          url: https://github.com/IBM/core-dump-handler/issues/62
   artifacthub.io/images: |
     - name: core-dump-handler
       image: quay.io/repository/icdh/core-dump-handler:v8.0.0

--- a/charts/core-dump-handler/Chart.yaml
+++ b/charts/core-dump-handler/Chart.yaml
@@ -10,9 +10,9 @@ sources:
 
 type: application
 
-version: v7.1.0
+version: v8.0.0
 
-appVersion: "v7.1.0"
+appVersion: "v8.0.0"
 
 icon: https://raw.githubusercontent.com/No9/core-dump-handler/master/assets/handle-with-care-svgrepo-com.svg
 
@@ -36,7 +36,7 @@ annotations:
           url: https://github.com/IBM/core-dump-handler/pull/58
   artifacthub.io/images: |
     - name: core-dump-handler
-      image: quay.io/repository/icdh/core-dump-handler:v7.1.0
+      image: quay.io/repository/icdh/core-dump-handler:v8.0.0
   artifacthub.io/license: MIT
   artifacthub.io/signKey: |
     fingerprint: BED079E67FD431E45301B1C9949E671B46AC8A34

--- a/charts/core-dump-handler/ci/inotify-manage-store.yaml
+++ b/charts/core-dump-handler/ci/inotify-manage-store.yaml
@@ -19,21 +19,24 @@ hostStorage: 1Gi
 coreStorage: 10Gi
 storageClass: hostclass
 
+composer:
+  ignoreCrio: false
+  crioImageCmd: "img"
+  logLevel: "Warn"
+  # Double curlies are required otherwise helm trys to parse the string
+  filenameTemplate: "{{uuid}}-dump-{{timestamp}}-{{hostname}}-{{exe_name}}-{{pid}}-{{signal}}"
+  logLength: 500
 
 daemonset:
   name: "core-dump-handler"
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
-  composerLogLevel: "Warn"
   suidDumpable: 2
   vendor: default
   # interval: 60000
   # schedule: "1/60 * * * * *"
   useINotify: true
-  composerIgnoreCrio: false
-  composerCrioImageCmd: "img"
-  DeployCrioConfig: false
   includeCrioExe: false
   # S3 access
   manageStoreSecret: true
@@ -61,7 +64,7 @@ affinity: {}
 
 # Tolerations for the daemonset's pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 # eg
 # - key: "key"
 #   operator: "Equal"

--- a/charts/core-dump-handler/ci/schedule-no-manage-store.yaml
+++ b/charts/core-dump-handler/ci/schedule-no-manage-store.yaml
@@ -19,21 +19,24 @@ hostStorage: 1Gi
 coreStorage: 10Gi
 storageClass: hostclass
 
+composer:
+  ignoreCrio: false
+  crioImageCmd: "img"
+  logLevel: "Warn"
+  # Double curlies are required otherwise helm trys to parse the string
+  filenameTemplate: "{{uuid}}-dump-{{timestamp}}-{{hostname}}-{{exe_name}}-{{pid}}-{{signal}}"
+  logLength: 500
 
 daemonset:
   name: "core-dump-handler"
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
-  composerLogLevel: "Warn"
   suidDumpable: 2
   vendor: default
   schedule: "1/60 * * * * *"
   # useINotify: true
   # interval: 1230
-  composerIgnoreCrio: false
-  composerCrioImageCmd: "img"
-  DeployCrioConfig: false
   includeCrioExe: false
   # S3 access
   manageStoreSecret: false
@@ -57,7 +60,7 @@ affinity: {}
 
 # Tolerations for the daemonset's pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 # eg
 # - key: "key"
 #   operator: "Equal"

--- a/charts/core-dump-handler/ci/tolerations.yaml
+++ b/charts/core-dump-handler/ci/tolerations.yaml
@@ -5,6 +5,7 @@ image:
   repository: icdh/core-dump-handler
   tag: main
   pullPolicy: Always
+  pullSecrets: []
   request_mem: "64Mi"
   request_cpu: "250m"
   limit_mem: "128Mi"
@@ -34,21 +35,27 @@ daemonset:
   coreDirectory: "/var/mnt/core-dump-handler/cores"
   suidDumpable: 2
   vendor: default
-  interval: 60000
+  # interval: 60000
   # schedule: "1/60 * * * * *"
-  # useINotify: false
+  useINotify: true
+  deployCrioConfig: false
   includeCrioExe: false
   # S3 access
   manageStoreSecret: true
-  s3AccessKey : XXX
-  s3Secret : XXX
-  s3BucketName : XXX
-  s3Region : XXX
+  s3AccessKey: XXX
+  s3Secret: XXX
+  s3BucketName: XXX
+  s3Region: XXX
   extraEnvVars: ""
 
 serviceAccount:
   create: true
   name: "core-dump-admin"
+
+# OpenShift specific for SecurityContextConstraints
+scc:
+  create: false
+  name: "core-dump-admin-privileged"
 
 clusterRole:
   name: "core-dump-event-reporter"
@@ -61,13 +68,17 @@ clusterRoleBinding:
 nodeSelector: {}
 # eg
 # gpu-enabled: true
-affinity: {}
-
-# Tolerations for the daemonset's pod assignment
-# ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
-# eg
-# - key: "key"
-#   operator: "Equal"
-#   value: "value"
-#   effect: "NoSchedule"
+tolerations:
+  - effect: NoSchedule
+    key: stage
+    operator: Equal
+    value: component
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: stage
+              operator: In
+              values:
+                - component

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -50,7 +50,10 @@
                     "$ref": "#/definitions/Affinity"
                 },
                 "tolerations": {
-                    "$ref": "#/definitions/Affinity"
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Affinity"
+                    }
                 }
             },
             "required": [

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   registry: quay.io
   repository: icdh/core-dump-handler
-  tag: v7.1.0
+  tag: v8.0.0
   pullPolicy: Always
   pullSecrets: []
   request_mem: "64Mi"
@@ -36,8 +36,8 @@ daemonset:
   suidDumpable: 2
   vendor: default
   # interval: 60000
-  # schedule: "1/60 * * * * *"
-  useINotify: true
+  schedule: "1/60 * * * * *"
+  # useINotify: true
   deployCrioConfig: false
   includeCrioExe: false
   # S3 access
@@ -72,7 +72,7 @@ affinity: {}
 
 # Tolerations for the daemonset's pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 # eg
 # - key: "key"
 #   operator: "Equal"

--- a/core-dump-agent/Cargo.toml
+++ b/core-dump-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-dump-agent"
-version = "7.0.0"
+version = "8.0.0"
 authors = ["Anthony Whalley <anton@venshare.com>"]
 edition = "2021"
 
@@ -13,7 +13,7 @@ env_logger = "0.9.0"
 log = "0.4.14"
 rust-s3 = { version = "0.27.0"}
 advisory-lock = "0.3.0"
-tokio-cron-scheduler = "0.2.3"
+tokio-cron-scheduler = "0.4.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 inotify = "0.9"
 thiserror = "1.0.30"

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -4,7 +4,7 @@ extern crate s3;
 use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use env_logger::Env;
 use inotify::{EventMask, Inotify, WatchMask};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use s3::bucket::Bucket;
 use s3::creds::Credentials;
 use s3::region::Region;
@@ -204,16 +204,18 @@ async fn main() -> Result<(), anyhow::Error> {
             match sched.add(s_job) {
                 Ok(v) => v,
                 Err(e) => {
-                    error!("Job Add failed {}", e);
-                    panic!("Job Scheduing failed, {}", e)
+                    error!("Job Add failed {:#?}", e);
+                    panic!("Job Scheduing failed, {:#?}", e)
                 }
             }
             info!("Added Job to Schedule");
             loop {
                 match sched.tick() {
-                    Ok(v) => v,
+                    Ok(_) => {
+                        debug!("Executed tick");
+                    }
                     Err(e) => {
-                        error!("Job Tick failed {}", e);
+                        error!("Job Tick failed {:#?}", e);
                     }
                 };
                 std::thread::sleep(Duration::from_millis(500));

--- a/core-dump-agent/tests/basic.rs
+++ b/core-dump-agent/tests/basic.rs
@@ -49,8 +49,9 @@ fn basic() -> Result<(), std::io::Error> {
         .env("SUID_DUMPABLE", "2")
         .env("CORE_DIR", &core_path)
         .env("LOCAL_BIN", &home_path)
+        .env("SCHEDULE", "1/1 * * * * *")
         .spawn()?;
-    thread::sleep(Duration::from_secs(2));
+    thread::sleep(Duration::from_secs(11));
     // This is very cludgy way of proceeding with the test.
     // The initialization and the running uploader should be split into two process.
     // and most of the code should be moved into structs to make it more testable.


### PR DESCRIPTION
Fix for https://github.com/IBM/core-dump-handler/issues/62
Bump latest version of tokio-cron-scheduler https://github.com/mvniekerk/tokio-cron-scheduler/releases/tag/0.4