### PR TITLE
Add ability to authenticate against AWS via STS

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -37,6 +37,9 @@ helm install core-dump-handler . --create-namespace --namespace observe \
     <td>AWS</td><td>EKS</td><td><a href="values.aws.yaml">values.aws.yaml</a></td>
 </tr>
 <tr>
+    <td>AWS</td><td>EKS with IAM roles for service accounts</td><td><a href="values.aws.sts.yaml">values.aws.yaml</a></td>
+</tr>
+<tr>
     <td>AWS</td><td>ROSA</td><td><a href="values.openshift.yaml">values.openshift.yaml</a></td>
 </tr>
 <tr>
@@ -139,6 +142,14 @@ Example S3 policy:
   ]
 }
 ```
+
+### EKS setup with IAM roles for service accounts
+
+This allows core-dump-handler to automatically assume the correct role with permissions on the S3 bucket without providing fixed credentials in the secret.
+
+See [this guide](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+[Example of `values.yaml`](values.aws.sts.yaml)
 
 ### Environment Variables
 

--- a/charts/core-dump-handler/templates/secrets.yaml
+++ b/charts/core-dump-handler/templates/secrets.yaml
@@ -5,8 +5,12 @@ metadata:
   name: s3config
 type: Opaque
 stringData:
+{{- if .Values.daemonset.s3Secret }}
   s3Secret: {{ .Values.daemonset.s3Secret }}
+{{- end }}
+{{- if .Values.daemonset.s3AccessKey }}
   s3AccessKey: {{ .Values.daemonset.s3AccessKey }}
+{{- end }}
   s3BucketName: {{ .Values.daemonset.s3BucketName }}
   s3Region: {{ .Values.daemonset.s3Region }}
 {{- end }}

--- a/charts/core-dump-handler/templates/serviceaccount.yaml
+++ b/charts/core-dump-handler/templates/serviceaccount.yaml
@@ -1,6 +1,12 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "core-dump-handler.serviceAccountName" . }}
   labels:
 {{ include "core-dump-handler.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/core-dump-handler/values.aws.sts.yaml
+++ b/charts/core-dump-handler/values.aws.sts.yaml
@@ -1,0 +1,9 @@
+# AWS requires a crio client to be copied to the server
+daemonset:
+  includeCrioExe: true
+  vendor: rhel7 # EKS EC2 images have an old libc=2.26
+
+serviceAccount:
+  annotations:
+    # See https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -280,6 +280,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "annotations": {
+                    "type": "object"
                 }
             },
             "required": [

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -50,6 +50,8 @@ daemonset:
 serviceAccount:
   create: true
   name: "core-dump-admin"
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
 
 # OpenShift specific for SecurityContextConstraints
 scc:

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -359,7 +359,9 @@ fn get_bucket() -> Result<Bucket, anyhow::Error> {
         }
     };
 
-    let credentials = if s3_access_key.is_empty() || s3_secret.is_empty() {
+    let credentials = if env::var("AWS_WEB_IDENTITY_TOKEN_FILE").is_ok() {
+        Credentials::from_sts_env(std::env!("CARGO_PKG_NAME"))
+    } else if s3_access_key.is_empty() || s3_secret.is_empty() {
         Credentials::new(None, None, None, None, None)
     } else {
         Credentials::new(
@@ -369,12 +371,12 @@ fn get_bucket() -> Result<Bucket, anyhow::Error> {
             None,
             None,
         )
-    };
+    }?;
 
     let s3 = Storage {
         name: "aws".into(),
         region,
-        credentials: credentials.unwrap(),
+        credentials,
         bucket: s3_bucket_name,
         location_supported: false,
     };


### PR DESCRIPTION
Hello, this patch makes it possible to use the preferred way to authenticate pods with AWS STS ([see here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)).
tl;dr without setting a keypair, but instead loading tokens from a mounted file handled by an admission controller.

I've tested it on our EKS deployment before submitting this PR.