### PR TITLE
configurable crictl endpoint

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -179,6 +179,11 @@ The agent pod has the following environment variables and these are all set by t
     "img" (Default): This is the value most crictls expect.
     "images": Digital Ocean, Newer OpenShift require this value
 
+* CRIO_ENDPOINT - The CRIO endpoint to use.
+
+    "unix:///run/containerd/containerd.sock" (Default): This is the default for most containerd nodes
+    "unix:///var/run/dockershim.sock": Should match most nodes that still use dockershim
+
 * COMP_FILENAME_TEMPLATE - Defines the template that generates the filename using [tinytemplate](https://crates.io/crates/tinytemplate#quickstart) and the [params object](https://github.com/IBM/core-dump-handler/blob/main/core-dump-composer/src/config.rs#L29)
 
 * DEPLOY_CRIO_CONFIG - Defines whether the agent should deploy a crictl config to the host

--- a/charts/core-dump-handler/ci/inotify-manage-store.yaml
+++ b/charts/core-dump-handler/ci/inotify-manage-store.yaml
@@ -32,6 +32,7 @@ daemonset:
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
+  crioEndpoint: "unix:///run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   # interval: 60000

--- a/charts/core-dump-handler/ci/interval-manage-store.yaml
+++ b/charts/core-dump-handler/ci/interval-manage-store.yaml
@@ -32,6 +32,7 @@ daemonset:
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
+  crioEndpoint: "unix:///run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   interval: 60000

--- a/charts/core-dump-handler/ci/schedule-no-manage-store.yaml
+++ b/charts/core-dump-handler/ci/schedule-no-manage-store.yaml
@@ -32,6 +32,7 @@ daemonset:
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
+  crioEndpoint: "unix:///run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   schedule: "1/60 * * * * *"

--- a/charts/core-dump-handler/ci/tolerations.yaml
+++ b/charts/core-dump-handler/ci/tolerations.yaml
@@ -33,6 +33,7 @@ daemonset:
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
+  crioEndpoint: "unix:///run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   # interval: 60000

--- a/charts/core-dump-handler/templates/daemonset.yaml
+++ b/charts/core-dump-handler/templates/daemonset.yaml
@@ -43,6 +43,8 @@ spec:
             value:  {{ .Values.composer.crioImageCmd }}
           - name: DEPLOY_CRIO_CONFIG
             value:  {{ .Values.daemonset.deployCrioConfig | quote }}
+          - name: CRIO_ENDPOINT
+            value:  {{ .Values.daemonset.crioEndpoint | quote }}
           - name: HOST_DIR
             value: {{ .Values.daemonset.hostDirectory }}
           - name: CORE_DIR

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -202,6 +202,9 @@
                 "deployCrioConfig": {
                     "type": "boolean"
                 },
+                "crioEndpoint": {
+                    "type": "string"
+                },
                 "includeCrioExe": {
                     "type": "boolean"
                 },

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -32,6 +32,7 @@ daemonset:
   label: "core-dump-ds"
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
+  crioEndpoint: "unix:///run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   # interval: 60000

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -417,9 +417,10 @@ async fn run_polling_agent(core_location: &str) {
 
 fn generate_crio_config(host_location: &str) -> Result<(), std::io::Error> {
     info!("Generating crio file");
+    let endpoint = env::var("CRIO_ENDPOINT").unwrap_or_else(|_| "unix:///run/containerd/containerd.sock".to_string());
     let destination = format!("{}/{}", host_location, "crictl.yaml");
     let mut crictl_file = File::create(destination)?;
-    let text = "runtime-endpoint: unix:///run/containerd/containerd.sock\nimage-endpoint: unix:///run/containerd/containerd.sock\ntimeout: 2\ndebug: false\npull-image-on-create: false";
+    let text = format!("runtime-endpoint: {}\nimage-endpoint: {}\ntimeout: 2\ndebug: false\npull-image-on-create: false", endpoint, endpoint);
     crictl_file.write_all(text.as_bytes())?;
     crictl_file.flush()?;
     Ok(())

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -417,7 +417,8 @@ async fn run_polling_agent(core_location: &str) {
 
 fn generate_crio_config(host_location: &str) -> Result<(), std::io::Error> {
     info!("Generating crio file");
-    let endpoint = env::var("CRIO_ENDPOINT").unwrap_or_else(|_| "unix:///run/containerd/containerd.sock".to_string());
+    let endpoint = env::var("CRIO_ENDPOINT")
+        .unwrap_or_else(|_| "unix:///run/containerd/containerd.sock".to_string());
     let destination = format!("{}/{}", host_location, "crictl.yaml");
     let mut crictl_file = File::create(destination)?;
     let text = format!("runtime-endpoint: {}\nimage-endpoint: {}\ntimeout: 2\ndebug: false\npull-image-on-create: false", endpoint, endpoint);


### PR DESCRIPTION
When `DEPLOY_CRIO_CONFIG` is `true`, both `image-endpoint` and `runtime-endpoint` are generated as hard coded values [here](https://github.com/IBM/core-dump-handler/blob/a67034ad7e807df956947b74b770a978235bf27b/core-dump-agent/src/main.rs#L422). This PR is to make them optionally configurable. To configure it, `daemonset.crioEndpoint` can now be set in `values.yaml`, which translates to the `CRIO_ENDPOINT` environment variable in the daemonset.

Found this useful on setups that have dockershim. The default is still set to `unix:///run/containerd/containerd.sock`, so this should be backwards compatible.