### PR TITLE
helm daemonset: Allow mounting the host container runtime socket

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -40,6 +40,9 @@ helm install core-dump-handler . --create-namespace --namespace observe \
     <td>AWS</td><td>EKS with IAM roles for service accounts</td><td><a href="values.aws.sts.yaml">values.aws.yaml</a></td>
 </tr>
 <tr>
+    <td>AWS</td><td>EKS with Bottlerocket nodes</td><td><a href="values.aws.bottlerocket.yaml">values.bottlerocket.yaml</a></td>
+</tr>
+<tr>
     <td>AWS</td><td>ROSA</td><td><a href="values.openshift.yaml">values.openshift.yaml</a></td>
 </tr>
 <tr>

--- a/charts/core-dump-handler/templates/daemonset.yaml
+++ b/charts/core-dump-handler/templates/daemonset.yaml
@@ -30,6 +30,10 @@ spec:
         - name: core-volume
           mountPath:  {{ .Values.daemonset.coreDirectory }}
           mountPropagation: Bidirectional
+        {{- if .Values.daemonset.mountContainerRuntimeEndpoint }}
+        - mountPath: {{ .Values.daemonset.hostContainerRuntimeEndpoint }}
+          name: container-runtime
+        {{- end }}
         env:
           - name: COMP_FILENAME_TEMPLATE
             value: {{ .Values.composer.filenameTemplate | quote }}
@@ -115,3 +119,8 @@ spec:
       - name: core-volume
         persistentVolumeClaim:
           claimName:  core-storage-pvc
+      {{- if .Values.daemonset.mountContainerRuntimeEndpoint }}
+      - name: container-runtime
+        hostPath:
+          path: {{ .Values.daemonset.hostContainerRuntimeEndpoint }}
+      {{- end }}

--- a/charts/core-dump-handler/values.aws.bottlerocket.yaml
+++ b/charts/core-dump-handler/values.aws.bottlerocket.yaml
@@ -1,0 +1,16 @@
+# AWS requires a crio client to be copied to the server
+daemonset:
+  includeCrioExe: true
+  deployCrioConfig: true
+  vendor: default
+  # Bottlerocket requires the host containerd socket mounted, it is located here as of 1.8.0
+  # Depending on the outcome of this issue, it may move in the future
+  # https://github.com/bottlerocket-os/bottlerocket/issues/2212
+  crioEndpoint: "unix:///run/dockershim.sock"
+  mountContainerRuntimeEndpoint: true
+  hostContainerRuntimeEndpoint: "/run/dockershim.sock"
+
+serviceAccount:
+  annotations:
+    # See https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -171,7 +171,19 @@
                             "s3Secret"
                         ]
                     }
-                }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "mountContainerRuntimeEndpoint": {
+                                "const": true
+                            }
+                        },
+                        "required": [
+                            "hostContainerRuntimeEndpoint"
+                        ]
+                    }
+                 }
             ],
             "properties": {
                 "name": {
@@ -206,6 +218,12 @@
                     "type": "boolean"
                 },
                 "crioEndpoint": {
+                    "type": "string"
+                },
+                "mountContainerRuntimeEndpoint": {
+                    "type": "boolean"
+                },
+                "hostContainerRuntimeEndpoint": {
                     "type": "string"
                 },
                 "includeCrioExe": {

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -34,6 +34,8 @@ daemonset:
   hostDirectory: "/var/mnt/core-dump-handler"
   coreDirectory: "/var/mnt/core-dump-handler/cores"
   crioEndpoint: "unix:///run/containerd/containerd.sock"
+  mountContainerRuntimeEndpoint: false
+  hostContainerRuntimeEndpoint: "/run/containerd/containerd.sock"
   suidDumpable: 2
   vendor: default
   # interval: 60000


### PR DESCRIPTION
Bottlerocket mounts the containerd socket under /run/dockershim.sock,
which does not appear to be part of the standard privileged container.
Add
  mountContainerRuntimeEndpoint: false
  hostContainerRuntimeEndpoint: "/run/containerd/containerd.sock"
 as chart defaults.

https://github.com/bottlerocket-os/bottlerocket/commit/91810c85b83ff4c3660b496e243ef8b55df0973b
https://github.com/bottlerocket-os/bottlerocket/issues/2212