### PR TITLE
Allow to disable ZIP compression & fix bug in overwriting info files 

### DIFF
--- a/core-dump-composer/src/config.rs
+++ b/core-dump-composer/src/config.rs
@@ -60,7 +60,7 @@ impl CoreConfig {
         let pathname = matches.value_of("pathname").unwrap_or("").to_string();
         let timeout = matches
             .value_of("timeout")
-            .unwrap_or("120")
+            .unwrap_or("600")
             .parse::<u64>()
             .unwrap();
         let disable_compression = matches.contains_id("disable-compression");

--- a/core-dump-composer/src/config.rs
+++ b/core-dump-composer/src/config.rs
@@ -26,6 +26,7 @@ pub struct CoreConfig {
     pub os_hostname: String,
     pub filename_template: String,
     pub params: CoreParams,
+    pub disable_compression: bool,
 }
 
 #[derive(Serialize)]
@@ -62,6 +63,7 @@ impl CoreConfig {
             .unwrap_or("120")
             .parse::<u64>()
             .unwrap();
+        let disable_compression = matches.contains_id("disable-compression");
 
         let uuid = Uuid::new_v4();
 
@@ -144,6 +146,7 @@ impl CoreConfig {
             filename_template,
             log_length,
             params,
+            disable_compression,
         })
     }
 
@@ -208,11 +211,11 @@ impl CoreConfig {
         format!("{}-ps-info.json", self.get_templated_name())
     }
 
-    pub fn get_image_filename(&self, counter: u32) -> String {
+    pub fn get_image_filename(&self, counter: usize) -> String {
         format!("{}-{}-image-info.json", self.get_templated_name(), counter)
     }
 
-    pub fn get_log_filename(&self, counter: u32) -> String {
+    pub fn get_log_filename(&self, counter: usize) -> String {
         format!("{}-{}.log", self.get_templated_name(), counter)
     }
     pub fn get_zip_full_path(&self) -> String {
@@ -314,6 +317,13 @@ pub fn try_get_matches() -> clap::Result<ArgMatches> {
                 .required(false)
                 .takes_value(true)
                 .help("test-threads mapped to support the test scenarios"),
+        )
+        .arg(
+            Arg::new("disable-compression")
+                .short('D')
+                .long("disable-compression")
+                .takes_value(false)
+                .help("Disables deflate compression in resulting zip file and stores data uncompressed."),
         )
         .try_get_matches()
 }

--- a/core-dump-composer/src/main.rs
+++ b/core-dump-composer/src/main.rs
@@ -305,8 +305,7 @@ fn handle(mut cc: config::CoreConfig) -> Result<(), anyhow::Error> {
     debug!("Successfully got the process details {}", ps_object);
 
     if let Some(containers) = ps_object["containers"].as_array() {
-        for container in containers {
-            let counter = 0;
+        for (counter, container) in containers.iter().enumerate() {
             let img_ref = match container["imageRef"].as_str() {
                 Some(v) => v,
                 None => {


### PR DESCRIPTION
This MR fixes two issues seen in a production environment:

* We have the problem that big core dumps were corrupted which can be fixed by using `io::copy` instead of  the manual read/write logic. It's unclear to me why because I am not a Rust guru. Another problem with big core dumps was that they turned out to be corrupted when compression is enabled. The `-D` flag works well for that and just stores data as-is in the resulting ZIP file.
* The `counter` variable to gather information on containers was never incremented thus overwriting previous container information. 