### PR TITLE
Update CDC tests to print out the stderr when tests fail

### DIFF
--- a/core-dump-composer/tests/default.rs
+++ b/core-dump-composer/tests/default.rs
@@ -67,6 +67,7 @@ fn default_scenario() -> Result<(), std::io::Error> {
         .expect("failed to execute core dump composer");
 
     println!("{}", String::from_utf8_lossy(&cdc.stdout));
+    println!("{}", String::from_utf8_lossy(&cdc.stderr));
 
     Command::new("unzip")
         .arg("output/*.zip")

--- a/core-dump-composer/tests/imagecommand.rs
+++ b/core-dump-composer/tests/imagecommand.rs
@@ -59,6 +59,7 @@ fn image_command_scenario() -> Result<(), std::io::Error> {
         .expect("failed to execute core dump composer");
 
     println!("{}", String::from_utf8_lossy(&cdc.stdout));
+    println!("{}", String::from_utf8_lossy(&cdc.stderr));
 
     Command::new("unzip")
         .arg("output/*.zip")

--- a/core-dump-composer/tests/namespacedfiles.rs
+++ b/core-dump-composer/tests/namespacedfiles.rs
@@ -68,6 +68,7 @@ fn namespaced_files_scenario() -> Result<(), std::io::Error> {
         .expect("failed to execute core dump composer");
 
     println!("{}", String::from_utf8_lossy(&cdc.stdout));
+    println!("{}", String::from_utf8_lossy(&cdc.stderr));
 
     Command::new("unzip")
         .arg("output/*.zip")

--- a/core-dump-composer/tests/timeout.rs
+++ b/core-dump-composer/tests/timeout.rs
@@ -65,7 +65,8 @@ fn timeout_scenario() -> Result<(), std::io::Error> {
         .output()
         .expect("Couldn't execute");
 
-    // FIXME: It would be nice to check the log output here.
+    println!("{}", String::from_utf8_lossy(&cdc.stdout));
+    println!("{}", String::from_utf8_lossy(&cdc.stderr));
     assert_eq!(32, *&cdc.status.code().unwrap());
     Ok(())
 }

--- a/core-dump-composer/tests/withoutcrio.rs
+++ b/core-dump-composer/tests/withoutcrio.rs
@@ -68,6 +68,7 @@ fn without_crio_scenario() -> Result<(), std::io::Error> {
         .expect("failed to execute core dump composer");
 
     println!("{}", String::from_utf8_lossy(&cdc.stdout));
+    println!("{}", String::from_utf8_lossy(&cdc.stderr));
 
     Command::new("unzip")
         .arg("output/*.zip")


### PR DESCRIPTION
When running the tests for the Core Dump Composer the error output was not being printed. This was making things a little difficult to track down where the tests might be failing if the Composer was hitting an error path.

This PR just adds `println!("{}", String::from_utf8_lossy(&cdc.stderr));` underneath all locations where `cdc.stdout` is already getting printed in the tests for the Composer