### PR TITLE
issue129: handle pullSecrets inside daemonset.yaml

### DIFF
--- a/charts/core-dump-handler/templates/daemonset.yaml
+++ b/charts/core-dump-handler/templates/daemonset.yaml
@@ -11,6 +11,10 @@ spec:
       labels:
         name: {{ .Values.daemonset.label }}
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: coredump-container
         image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION

In charts, pullSecrets is present in values.yaml but is not being used inside templates/daemonset.yaml.


Signed-off-by: Rohit Saini <rsaini@a5gnet.com>