### PR TITLE
Add more parameters to helm chart

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -323,3 +323,5 @@ Daemonset
 * s3BucketName : Maps to the S3_BUCKET_NAME enviroment variable
 * 3Region : Maps to the S3_REGION enviroment variable
 * extraEnvVars: Option for passing additional configuration to the agent such as endpoint properties.
+* envFrom: Array of [EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envfromsource-v1-core) to inject into main container.
+* sidecarContainers: Array of [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core) to define as part of the pod.

--- a/charts/core-dump-handler/templates/_helpers.tpl
+++ b/charts/core-dump-handler/templates/_helpers.tpl
@@ -73,3 +73,21 @@ Basically copied from https://github.com/bitnami/charts/blob/master/bitnami/comm
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{- define "core-dump-handler.daemonset.container.volumeMounts" -}}
+- name: host-volume
+  mountPath:  {{ .Values.daemonset.hostDirectory }}
+  mountPropagation: Bidirectional
+- name: core-volume
+  mountPath:  {{ .Values.daemonset.coreDirectory }}
+  mountPropagation: Bidirectional
+{{- if .Values.composer.coreEvents }}
+- name: event-volume
+  mountPath:  {{ .Values.daemonset.eventDirectory }}
+  mountPropagation: Bidirectional
+{{- end }}
+{{- if .Values.daemonset.mountContainerRuntimeEndpoint }}
+- mountPath: {{ .Values.daemonset.hostContainerRuntimeEndpoint }}
+  name: container-runtime
+{{- end }}
+{{- end -}}

--- a/charts/core-dump-handler/templates/daemonset.yaml
+++ b/charts/core-dump-handler/templates/daemonset.yaml
@@ -10,6 +10,8 @@ spec:
     metadata:
       labels:
         name: {{ .Values.daemonset.label }}
+      annotations:
+        kubectl.kubernetes.io/default-container: "coredump-container"
     spec:
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -28,22 +30,7 @@ spec:
             cpu: {{ .Values.image.limit_cpu }}
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: host-volume
-          mountPath:  {{ .Values.daemonset.hostDirectory }}
-          mountPropagation: Bidirectional
-        - name: core-volume
-          mountPath:  {{ .Values.daemonset.coreDirectory }}
-          mountPropagation: Bidirectional
-        {{- if .Values.composer.coreEvents }}
-        - name: event-volume
-          mountPath:  {{ .Values.daemonset.eventDirectory }}
-          mountPropagation: Bidirectional
-        {{- end }}  
-        {{- if .Values.daemonset.mountContainerRuntimeEndpoint }}
-        - mountPath: {{ .Values.daemonset.hostContainerRuntimeEndpoint }}
-          name: container-runtime
-        {{- end }}
+        volumeMounts: {{ include "core-dump-handler.daemonset.container.volumeMounts" . | nindent 10 }}
         env:
           - name: COMP_FILENAME_TEMPLATE
             value: {{ .Values.composer.filenameTemplate | quote }}
@@ -114,11 +101,28 @@ spec:
           {{- if .Values.daemonset.extraEnvVars }}
           {{ include "core-dump-handler.tplvalues.render" ( dict "value" .Values.daemonset.extraEnvVars "context" $) | nindent 10  }}
           {{- end }}
+        {{- with .Values.daemonset.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command: ["/app/core-dump-agent"]
         lifecycle:
           preStop:
             exec:
               command: ["/app/core-dump-agent", "remove"]
+      {{- range .Values.daemonset.sidecarContainers }}
+      - {{ with . -}}
+        securityContext:
+          privileged: true
+        volumeMounts:
+          {{- include "core-dump-handler.daemonset.container.volumeMounts" $ | nindent 10 }}
+          {{- if  .volumeMounts -}}
+          {{- toYaml .volumeMounts | nindent 10 }}
+          {{- end }}
+        {{- $_ := unset . "volumeMounts" -}}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/core-dump-handler/values.minikube.yaml
+++ b/charts/core-dump-handler/values.minikube.yaml
@@ -1,12 +1,22 @@
 storageClass: standard
 image:
   tag: latest
-  pullPolicy: Never
 composer:
   logLevel: "Debug"
+  coreEvents: true
 daemonset:
   mountContainerRuntimeEndpoint: true
   hostContainerRuntimeEndpoint: "/var/run/cri-dockerd.sock"
   crioEndpoint: "unix:///var/run/cri-dockerd.sock"
   deployCrioConfig: true
   includeCrioExe: true
+  sidecarContainers:
+  - name: simple-printer
+    image: alpine
+    command:
+    - /bin/sh
+    - -c
+    - |
+      apk --no-cache add inotify-tools
+      cd /var/mnt/core-dump-handler/events
+      inotifywait -mq -e create .| while read directory action file; do cat $file; done

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -262,6 +262,12 @@
                 },
                 "extraEnvVars": {
                     "type": "string"
+                },
+                "envFrom": {
+                    "type": "array"
+                },
+                "sidecarContainers": {
+                    "type": "array"
                 }
             },
             "required": [

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -55,6 +55,8 @@ daemonset:
   s3BucketName: XXX
   s3Region: XXX
   extraEnvVars: ""
+  envFrom: []
+  sidecarContainers: []
 
 serviceAccount:
   create: true


### PR DESCRIPTION
- Helm chart now supports injecting sidecar containers, adding envvars with `envFrom` instructions to read either configMaps as well as secrets.

- Add sample sidecar to minikube values that prints the event file to stdout
