### PR TITLE
Add updateStrategy to helm chart

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -325,3 +325,4 @@ Daemonset
 * extraEnvVars: Option for passing additional configuration to the agent such as endpoint properties.
 * envFrom: Array of [EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envfromsource-v1-core) to inject into main container.
 * sidecarContainers: Array of [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core) to define as part of the pod.
+* updateStrategy: [DaemonsetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#daemonsetupdatestrategy-v1-apps) is a struct used to control the update strategy for the DaemonSet.

--- a/charts/core-dump-handler/templates/daemonset.yaml
+++ b/charts/core-dump-handler/templates/daemonset.yaml
@@ -6,6 +6,10 @@ spec:
   selector:
     matchLabels:
       name: {{ .Values.daemonset.label }}
+  {{- with .Values.daemonset.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/core-dump-handler/values.minikube.yaml
+++ b/charts/core-dump-handler/values.minikube.yaml
@@ -5,6 +5,10 @@ composer:
   logLevel: "Debug"
   coreEvents: true
 daemonset:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   mountContainerRuntimeEndpoint: true
   hostContainerRuntimeEndpoint: "/var/run/cri-dockerd.sock"
   crioEndpoint: "unix:///var/run/cri-dockerd.sock"

--- a/charts/core-dump-handler/values.schema.json
+++ b/charts/core-dump-handler/values.schema.json
@@ -268,6 +268,9 @@
                 },
                 "sidecarContainers": {
                     "type": "array"
+                },
+                "updateStrategy": {
+                    "type": "object"
                 }
             },
             "required": [

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -57,6 +57,7 @@ daemonset:
   extraEnvVars: ""
   envFrom: []
   sidecarContainers: []
+  updateStrategy: {}
 
 serviceAccount:
   create: true


### PR DESCRIPTION
@No9 one more field to release to helm chart. I notice that rolling changes for larger K8s cluster (100+ nodes) may take a while, so in order to allow users to speed rollouts, they can now set other update strategy. 