### PR TITLE
Chart value "composer.logLength" doesn't affect.

### DIFF
--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -474,7 +474,7 @@ fn create_env_file(host_location: &str) -> Result<(), std::io::Error> {
     let filename_template = env::var("COMP_FILENAME_TEMPLATE").unwrap_or_else(|_| {
         "{uuid}-dump-{timestamp}-{hostname}-{exe_name}-{pid}-{signal}".to_string()
     });
-    let log_length = env::var("LOG_LENGTH").unwrap_or_else(|_| "500".to_string());
+    let log_length = env::var("COMP_LOG_LENGTH").unwrap_or_else(|_| "500".to_string());
     let pod_selector_label = env::var("COMP_POD_SELECTOR_LABEL").unwrap_or_default();
     let timeout = env::var("COMP_TIMEOUT").unwrap_or_else(|_| "600".to_string());
 


### PR DESCRIPTION
Hi @No9.

I found that the chart value `composer.logLength` doesn't affect to the composer's actual setting value `LOG_LENGTH`.
Then it's just used the default value 500 even though I specify it like this.
```
helm install core-dump-handler . --set composer.logLength=10
``` 
Because core-dump-agent doesn't read the environment variable "COMP_LOG_LENGTH" passed from `daemonset.yaml`.