### PR TITLE
Add service account token secret

### DIFF
--- a/charts/core-dump-handler/README.md
+++ b/charts/core-dump-handler/README.md
@@ -326,3 +326,7 @@ Daemonset
 * envFrom: Array of [EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envfromsource-v1-core) to inject into main container.
 * sidecarContainers: Array of [Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#container-v1-core) to define as part of the pod.
 * updateStrategy: [DaemonsetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#daemonsetupdatestrategy-v1-apps) is a struct used to control the update strategy for the DaemonSet.
+
+Service account:
+* useToken: automatically create a service account token secret
+* tokenSecretName: name of the service account token secret to create if `serviceAccount.useToken` is `true` (Default: "core-dump-service-account-token")

--- a/charts/core-dump-handler/templates/sa-token-secret.yaml
+++ b/charts/core-dump-handler/templates/sa-token-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.useToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default "core-dump-service-account-token" .Values.serviceAccount.tokenSecretName }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "core-dump-handler.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/core-dump-handler/values.aws.yaml
+++ b/charts/core-dump-handler/values.aws.yaml
@@ -2,3 +2,6 @@
 daemonset:
   includeCrioExe: true
   vendor: rhel7 # EKS EC2 images have an old libc=2.26
+
+serviceAccount:
+  useToken: true

--- a/charts/core-dump-handler/values.yaml
+++ b/charts/core-dump-handler/values.yaml
@@ -64,6 +64,8 @@ serviceAccount:
   name: "core-dump-admin"
   # annotations:
   #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+  useToken: false
+  tokenSecretName: core-dump-service-account-token
 
 # OpenShift specific for SecurityContextConstraints
 scc:


### PR DESCRIPTION
Adds a new secret to be compatible with EKS >= 1.24 (see https://aws.github.io/aws-eks-best-practices/security/docs/iam/). 

This closes https://github.com/IBM/core-dump-handler/issues/143 and closes https://github.com/IBM/core-dump-handler/issues/140. 

Open design questions:
* ~put token secret in dedicated file?~
* ~make secret name configurable?~
* add token conditionally (for example only for versions later than 1.24 based on [`KubeVersion`](https://helm.sh/docs/chart_template_guide/builtin_objects/)?
* ~add specific flag to toggle token secret creation?~

Let me know what you think :smiley: 
