### PR TITLE
Fix use of try_lock and lock methods to explicitly use AdvisoryFileLock trait implementation for std::fs::File in core_dump_handler

### DIFF
--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -292,7 +292,7 @@ async fn process_file(zip_path: &Path, bucket: &Bucket) {
 
     let f = File::open(zip_path).expect("no file found");
 
-    match AdvisoryFileLock.try_lock(&f, FileLockMode::Shared) {
+    match AdvisoryFileLock::try_lock(&f, FileLockMode::Shared) {
         Ok(_) => { /* If we can lock then we are ok */ }
         Err(e) => {
             let l_inotify = env::var("USE_INOTIFY")

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -292,7 +292,7 @@ async fn process_file(zip_path: &Path, bucket: &Bucket) {
 
     let f = File::open(zip_path).expect("no file found");
 
-    match f.try_lock(FileLockMode::Shared) {
+    match AdvisoryFileLock.try_lock(&f, FileLockMode::Shared) {
         Ok(_) => { /* If we can lock then we are ok */ }
         Err(e) => {
             let l_inotify = env::var("USE_INOTIFY")

--- a/core-dump-composer/src/events.rs
+++ b/core-dump-composer/src/events.rs
@@ -87,7 +87,7 @@ impl CoreEvent {
     pub fn write_event(&self, eventlocation: &str) -> Result<(), anyhow::Error> {
         let full_path = format!("{}/{}-event.json", eventlocation, self.uuid);
         let file = File::create(full_path)?;
-        file.lock(FileLockMode::Exclusive)?;
+        AdvisoryFileLock.lock(&file, FileLockMode::Exclusive)?;
         serde_json::to_writer(&file, &self)?;
         file.unlock()?;
         Ok(())

--- a/core-dump-composer/src/events.rs
+++ b/core-dump-composer/src/events.rs
@@ -87,7 +87,7 @@ impl CoreEvent {
     pub fn write_event(&self, eventlocation: &str) -> Result<(), anyhow::Error> {
         let full_path = format!("{}/{}-event.json", eventlocation, self.uuid);
         let file = File::create(full_path)?;
-        AdvisoryFileLock.lock(&file, FileLockMode::Exclusive)?;
+        AdvisoryFileLock::lock(&file, FileLockMode::Exclusive)?;
         serde_json::to_writer(&file, &self)?;
         file.unlock()?;
         Ok(())

--- a/core-dump-composer/src/main.rs
+++ b/core-dump-composer/src/main.rs
@@ -131,7 +131,7 @@ fn handle(mut cc: config::CoreConfig) -> Result<(), anyhow::Error> {
             process::exit(1);
         }
     };
-    file.lock(FileLockMode::Exclusive)?;
+    AdvisoryFileLock.lock(FileLockMode::Exclusive)?;
     let mut zip = ZipWriter::new(&file);
 
     debug!(

--- a/core-dump-composer/src/main.rs
+++ b/core-dump-composer/src/main.rs
@@ -131,7 +131,7 @@ fn handle(mut cc: config::CoreConfig) -> Result<(), anyhow::Error> {
             process::exit(1);
         }
     };
-    AdvisoryFileLock.lock(FileLockMode::Exclusive)?;
+    AdvisoryFileLock.lock(&file, FileLockMode::Exclusive)?;
     let mut zip = ZipWriter::new(&file);
 
     debug!(

--- a/core-dump-composer/src/main.rs
+++ b/core-dump-composer/src/main.rs
@@ -131,7 +131,7 @@ fn handle(mut cc: config::CoreConfig) -> Result<(), anyhow::Error> {
             process::exit(1);
         }
     };
-    AdvisoryFileLock.lock(&file, FileLockMode::Exclusive)?;
+    AdvisoryFileLock::lock(&file, FileLockMode::Exclusive)?;
     let mut zip = ZipWriter::new(&file);
 
     debug!(


### PR DESCRIPTION
This PR fixes the usage of the try_lock/lock method in the core_dump_composer and core_dump_agent modules of the core-dump-handler project.
Specifically, it enforces the use of the try_lock/lock implementation from the AdvisoryFileLock trait provided by the advisory-lock crate for the std::fs::File type.

This change is necessary to prevent compilation errors on Rust versions 1.89.0 and above, where the compiler tries to call the try_lock/lock method directly from the standard library's std::fs::File instead of from the advisory-lock crate.

With this fix, the code explicitly scopes the try_lock/lock call to AdvisoryFileLock, ensuring compatibility with newer Rust versions and avoiding ambiguous method call errors.

The fix improves stability and future-proofing of the file locking mechanism in core-dump-handler.