### PR TITLE
update so that project can run on latest crictl version

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.14
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi7/ubi as rhel7builder
+FROM registry.access.redhat.com/ubi7/ubi AS rhel7builder
+
+ARG CRICTL_VERSION=1.33.0
 
 RUN yum install -y gcc openssl-devel && \
     rm -rf /var/cache/dnf && \
@@ -12,7 +14,7 @@ ENV PATH=/root/.cargo/bin:${PATH}
 
 RUN cargo build --release -p core-dump-composer
 
-FROM registry.access.redhat.com/ubi8/ubi as rhel8builder
+FROM registry.access.redhat.com/ubi8/ubi AS rhel8builder
 
 RUN yum install -y gcc openssl-devel && \
     rm -rf /var/cache/dnf && \
@@ -26,8 +28,8 @@ ENV PATH=/root/.cargo/bin:${PATH}
 
 RUN cargo build --release
 
-RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz --output crictl-v1.22.0-linux-amd64.tar.gz
-RUN tar zxvf crictl-v1.22.0-linux-amd64.tar.gz
+RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz
+RUN tar zxvf crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi7/ubi AS rhel7builder
 
-ARG CRICTL_VERSION=1.33.0
-
 RUN yum install -y gcc openssl-devel && \
     rm -rf /var/cache/dnf && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -15,6 +13,8 @@ ENV PATH=/root/.cargo/bin:${PATH}
 RUN cargo build --release -p core-dump-composer
 
 FROM registry.access.redhat.com/ubi8/ubi AS rhel8builder
+
+ARG CRICTL_VERSION=1.33.0
 
 RUN yum install -y gcc openssl-devel && \
     rm -rf /var/cache/dnf && \

--- a/core-dump-agent/src/main.rs
+++ b/core-dump-agent/src/main.rs
@@ -1,7 +1,6 @@
 extern crate dotenv;
 extern crate s3;
 
-use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use env_logger::Env;
 use inotify::{EventMask, Inotify, WatchMask};
 use log::{error, info, warn};
@@ -292,7 +291,7 @@ async fn process_file(zip_path: &Path, bucket: &Bucket) {
 
     let f = File::open(zip_path).expect("no file found");
 
-    match f.try_lock(FileLockMode::Shared) {
+    match f.try_lock_shared() {
         Ok(_) => { /* If we can lock then we are ok */ }
         Err(e) => {
             let l_inotify = env::var("USE_INOTIFY")

--- a/core-dump-composer/src/events.rs
+++ b/core-dump-composer/src/events.rs
@@ -1,5 +1,4 @@
 use crate::config::CoreParams;
-use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -87,7 +86,7 @@ impl CoreEvent {
     pub fn write_event(&self, eventlocation: &str) -> Result<(), anyhow::Error> {
         let full_path = format!("{}/{}-event.json", eventlocation, self.uuid);
         let file = File::create(full_path)?;
-        file.lock(FileLockMode::Exclusive)?;
+        file.lock_shared()?;
         serde_json::to_writer(&file, &self)?;
         file.unlock()?;
         Ok(())

--- a/core-dump-composer/src/main.rs
+++ b/core-dump-composer/src/main.rs
@@ -2,7 +2,6 @@ extern crate dotenv;
 
 use crate::events::CoreEvent;
 
-use advisory_lock::{AdvisoryFileLock, FileLockMode};
 use libcrio::Cli;
 use log::{debug, error, info, warn};
 use serde_json::json;
@@ -131,7 +130,7 @@ fn handle(mut cc: config::CoreConfig) -> Result<(), anyhow::Error> {
             process::exit(1);
         }
     };
-    file.lock(FileLockMode::Exclusive)?;
+    file.lock_shared()?;
     let mut zip = ZipWriter::new(&file);
 
     debug!(

--- a/musl.Dockerfile
+++ b/musl.Dockerfile
@@ -1,12 +1,12 @@
-FROM docker.io/alpine:3.15.4 as builder
-
+FROM docker.io/alpine:3.23.3 AS builder
 ARG ARCH
+ARG CRICTL_VERSION=1.33.0
 
-RUN apk update && apk add curl binutils build-base
+RUN apk update && apk add curl binutils build-base openssl-dev openssl-libs-static
 
 RUN if [ $ARCH == "amd64" ]; then curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable-x86_64-unknown-linux-musl -y; fi
 
-RUN if [ $ARCH == "arm64" ]; then curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.61.0-aarch64-unknown-linux-musl -y; fi
+RUN if [ $ARCH == "arm64" ]; then curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable-aarch64-unknown-linux-musl -y; fi
 
 RUN ls -a /root/.cargo/bin
 
@@ -17,10 +17,10 @@ WORKDIR "/app-build"
 ENV PATH=/root/.cargo/bin:${PATH}
 RUN cargo build --verbose --release
 
-RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-$ARCH.tar.gz --output crictl-v1.22.0-linux-$ARCH.tar.gz
-RUN tar zxvf crictl-v1.22.0-linux-$ARCH.tar.gz
+RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-$ARCH.tar.gz --output crictl-v${CRICTL_VERSION}-linux-$ARCH.tar.gz
+RUN tar zxvf crictl-v${CRICTL_VERSION}-linux-$ARCH.tar.gz
 
-FROM docker.io/alpine:3.15.4
+FROM docker.io/alpine:3.23.3
 
 RUN apk update && apk add procps
 


### PR DESCRIPTION
The current version of `core-dump-handler` doesn't work with Kubernetes 1.33 and beyond.
This PR updates the `musl` version, which is multiarch, to the latest version of crictl and also makes the crictl version an build-arg in case someone needs to update it.

Running the docker file seems to fail on compiling, so this PR also includes fixes to latest rust compatibility.