### PR TITLE
add arch as an option paramater for the naming template

### DIFF
--- a/core-dump-composer/src/config.rs
+++ b/core-dump-composer/src/config.rs
@@ -47,6 +47,7 @@ pub struct CoreParams {
     pub namespace: Option<String>,
     pub podname: Option<String>,
     pub uuid: Uuid,
+    pub arch: String,
 }
 
 static DEFAULT_TEMPLATE: &str = "{uuid}-dump-{timestamp}-{hostname}-{exe_name}-{pid}-{signal}";
@@ -64,6 +65,7 @@ impl CoreConfig {
         let pathname = matches.value_of("pathname").unwrap_or("").to_string();
 
         let uuid = Uuid::new_v4();
+        let arch = std::env::consts::ARCH.to_string();
 
         let params = CoreParams {
             limit_size,
@@ -77,6 +79,7 @@ impl CoreConfig {
             namespace: None,
             podname: None,
             uuid,
+            arch
         };
 
         let mut dot_env_path = env::current_exe()?;
@@ -374,6 +377,18 @@ mod tests {
         config.filename_template = "{namespace}".to_string();
         let just_namespace = config.get_templated_name();
         assert_eq!(just_namespace, "anamespace".to_string());
+    }
+    #[test]
+    fn arch_is_rendered() {
+        let mut config = match CoreConfig::new() {
+            Ok(v) => v,
+            Err(e) => panic!("Generation of CoreConfig failed. {}", e),
+        };
+        let templated_name = config.get_templated_name();
+        assert!(templated_name.contains("-dump-----"));
+        config.filename_template = "{arch}".to_string();
+        let just_arch = config.get_templated_name();
+        assert_eq!(just_arch, std::env::consts::ARCH);
     }
     #[test]
     fn default_template_test() {

--- a/core-dump-composer/src/events.rs
+++ b/core-dump-composer/src/events.rs
@@ -154,6 +154,7 @@ mod tests {
         let pathname = "pathname".to_string();
         let uuid = Uuid::new_v4();
         let podname = "podname".to_string();
+        let arch = "arch".to_string();
 
         let params = CoreParams {
             limit_size,
@@ -167,6 +168,7 @@ mod tests {
             namespace: None,
             uuid,
             podname: Some(podname),
+            arch
         };
         let pod = json!(
            {
@@ -236,6 +238,7 @@ mod tests {
         let pathname = "pathname".to_string();
         let uuid = Uuid::new_v4();
         let podname = "podname".to_string();
+        let arch = "arch".to_string();
 
         let params = CoreParams {
             limit_size,
@@ -249,6 +252,7 @@ mod tests {
             namespace: None,
             uuid,
             podname: Some(podname),
+            arch
         };
         let image1 = json!({
           "id": "sha256:3b8adc6c30f4e7e4afb57daef9d1c8af783a4a647a4670780e9df085c0525efa",


### PR DESCRIPTION
For us, we run the `core-dump-handler` in a multi arch environment, so it is crucial for us to know which architecture the core was a run on.
So, to enable easier checking, this PR introduces the `ARCH` flag to naming template, for people that need this information. It is not included in the name by default.